### PR TITLE
Fuse start error handling

### DIFF
--- a/cmd/args.go
+++ b/cmd/args.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/cyverse/go-irodsclient/client"
 	"github.com/cyverse/irodsfs/pkg/irodsfs"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 	"gopkg.in/yaml.v2"
 
 	log "github.com/sirupsen/logrus"
@@ -157,7 +157,7 @@ func inputMissingParams(config *irodsfs.Config, stdinClosed bool) error {
 		}
 
 		fmt.Print("Password: ")
-		bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+		bytePassword, err := term.ReadPassword(int(syscall.Stdin))
 		fmt.Print("\n")
 		if err != nil {
 			logger.WithError(err).Error("Error occurred while reading password")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,18 +1,32 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/cyverse/irodsfs/pkg/irodsfs"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
+
+const (
+	InterProcessCommunicationFinishSuccess string = "<<COMMUNICATION_CLOSE_SUCCESS>>"
+	InterProcessCommunicationFinishError   string = "<<COMMUNICATION_CLOSE_ERROR>>"
+)
+
+type NilWriter struct{}
+
+// Write does nothing
+func (w *NilWriter) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
 
 func main() {
 	// check if this is subprocess running in the background
@@ -61,6 +75,14 @@ func parentRun(irodsfsExec string, config *irodsfs.Config) error {
 			return err
 		}
 
+		subStdout, err := cmd.StdoutPipe()
+		if err != nil {
+			logger.WithError(err).Error("Could not communicate to background process")
+			return err
+		}
+
+		cmd.Stderr = cmd.Stdout
+
 		err = cmd.Start()
 		if err != nil {
 			logger.WithError(err).Errorf("Could not start a child process")
@@ -82,11 +104,44 @@ func parentRun(irodsfsExec string, config *irodsfs.Config) error {
 			logger.WithError(err).Error("Could not communicate to background process")
 			return err
 		}
-		logger.Info("Successfully sent configuration data")
+		subStdin.Close()
+		logger.Info("Successfully sent configuration data to background process")
 
+		childProcessFailed := false
+
+		// receive output from child
+		subOutputScanner := bufio.NewScanner(subStdout)
+		for {
+			if subOutputScanner.Scan() {
+				errMsg := strings.TrimSpace(subOutputScanner.Text())
+				if errMsg == InterProcessCommunicationFinishSuccess {
+					logger.Info("Successfully started background process")
+					break
+				} else if errMsg == InterProcessCommunicationFinishError {
+					logger.Error("Failed to start background process")
+					childProcessFailed = true
+					break
+				} else {
+					fmt.Fprintln(os.Stderr, errMsg)
+				}
+			} else {
+				// check err
+				if subOutputScanner.Err() != nil {
+					logger.Error(subOutputScanner.Err().Error())
+					childProcessFailed = true
+					break
+				}
+			}
+		}
+
+		subStdout.Close()
+
+		if childProcessFailed {
+			return fmt.Errorf("Failed to start background process")
+		}
 	} else {
 		// foreground
-		err = run(config)
+		err = run(config, false)
 		if err != nil {
 			logger.WithError(err).Error("Could not run irodsfs")
 			return err
@@ -145,38 +200,37 @@ func childMain() {
 		"function": "childMain",
 	})
 
-	// output to default log
-	logFile, err := os.OpenFile("/tmp/irodsfs.log", os.O_WRONLY|os.O_CREATE, 0755)
-	if err != nil {
-		logger.WithError(err).Error("Could not create log file")
-	} else {
-		log.SetOutput(logFile)
-	}
+	logger.Info("Start background process")
 
 	// read from stdin
-	_, err = os.Stdin.Stat()
+	_, err := os.Stdin.Stat()
 	if err != nil {
 		logger.WithError(err).Error("Could not communicate to foreground process")
-		logger.Fatal(err)
+		fmt.Fprintln(os.Stderr, InterProcessCommunicationFinishError)
+		os.Exit(1)
 	}
 
 	configBytes, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
 		logger.WithError(err).Error("Could not read configuration")
-		logger.Fatal(err)
+		fmt.Fprintln(os.Stderr, InterProcessCommunicationFinishError)
+		os.Exit(1)
 	}
 
 	config, err := irodsfs.NewConfigFromYAML(configBytes)
 	if err != nil {
 		logger.WithError(err).Error("Could not read configuration")
-		logger.Fatal(err)
+		fmt.Fprintln(os.Stderr, InterProcessCommunicationFinishError)
+		os.Exit(1)
 	}
 
 	// output to default log
 	if len(config.LogPath) > 0 {
-		logFile, err = os.OpenFile(config.LogPath, os.O_WRONLY|os.O_CREATE, 0755)
+		logFile, err := os.OpenFile(config.LogPath, os.O_WRONLY|os.O_CREATE, 0755)
 		if err != nil {
 			logger.WithError(err).Error("Could not create log file")
+			fmt.Fprintln(os.Stderr, InterProcessCommunicationFinishError)
+			os.Exit(1)
 		} else {
 			log.SetOutput(logFile)
 		}
@@ -185,18 +239,19 @@ func childMain() {
 	err = config.Validate()
 	if err != nil {
 		logger.WithError(err).Error("Argument validation error")
-		logger.Fatal(err)
+		fmt.Fprintln(os.Stderr, InterProcessCommunicationFinishError)
+		os.Exit(1)
 	}
 
 	// background
-	err = run(config)
+	err = run(config, true)
 	if err != nil {
 		logger.WithError(err).Error("Could not run irodsfs")
-		logger.Fatal(err)
+		os.Exit(1)
 	}
 }
 
-func run(config *irodsfs.Config) error {
+func run(config *irodsfs.Config, isChildProcess bool) error {
 	logger := log.WithFields(log.Fields{
 		"package":  "main",
 		"function": "run",
@@ -205,6 +260,9 @@ func run(config *irodsfs.Config) error {
 	fs, err := irodsfs.NewFileSystem(config)
 	if err != nil {
 		logger.WithError(err).Error("Could not create filesystem")
+		if isChildProcess {
+			fmt.Fprintln(os.Stderr, InterProcessCommunicationFinishError)
+		}
 		return err
 	}
 
@@ -213,16 +271,42 @@ func run(config *irodsfs.Config) error {
 
 	go func() {
 		<-signalChan
+		if isChildProcess {
+			fmt.Fprintln(os.Stderr, InterProcessCommunicationFinishError)
+		}
+
 		fs.Destroy()
+		os.Exit(0)
 	}()
+
+	err = fs.ConnectToFuse()
+	if err != nil {
+		logger.Error(err)
+		if isChildProcess {
+			fmt.Fprintln(os.Stderr, InterProcessCommunicationFinishError)
+		}
+
+		fs.Destroy()
+		return err
+	}
+
+	if isChildProcess {
+		fmt.Fprintln(os.Stdout, InterProcessCommunicationFinishSuccess)
+		if len(config.LogPath) == 0 {
+			// stderr is not a local file, so is closed by parent
+			var nilWriter NilWriter
+			log.SetOutput(&nilWriter)
+		}
+	}
 
 	err = fs.StartFuse()
 	if err != nil {
-		fs.Destroy()
 		logger.WithError(err).Error("Could not start FUSE")
+		fs.Destroy()
 		return err
 	}
 
 	// returns if mount fails, or stopped.
+	fs.Destroy()
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,6 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/sirupsen/logrus v1.8.0
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
+	golang.org/x/term v0.0.0-20210503060354-a79de5458b56
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,12 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+golang.org/x/term v0.0.0-20210503060354-a79de5458b56 h1:b8jxX3zqjpqb2LklXPzKSGJhzyxCOZSz8ncv8Nv+y7w=
+golang.org/x/term v0.0.0-20210503060354-a79de5458b56/go.mod h1:tfny5GFUkzUvx4ps4ajbZsCe5lw1metzhBm9T3x7oIY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200423201157-2723c5de0d66/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=


### PR DESCRIPTION
Rework parent-child process communication to print error messages

parent process checks stderr and stdout of child process and prints out until it sees Predefined error messages. Then exists the parent process.