### PR TITLE
Fix a mistake in ssl_config.yml

### DIFF
--- a/examples/ssl_config.yml
+++ b/examples/ssl_config.yml
@@ -5,7 +5,7 @@ client_user: iychoi
 zone: iplant
 password:
 
-auth_scheme: "pam"
+authscheme: "pam"
 ssl_ca_cert_file: "/etc/ssl/certs/ca-certificates.crt"
 ssl_encryption_key_size: 32
 ssl_encryption_algorithm: "AES-256-CBC"


### PR DESCRIPTION
Fix mistake in ssl_config.yml.
As discovered in issue #18, it has to be `authscheme` instead of `auth_scheme`